### PR TITLE
fix: isAtLeastHalfOpenLine の盤外読み出しを修正 (#13)

### DIFF
--- a/src/board.c
+++ b/src/board.c
@@ -173,15 +173,18 @@ BOOL isOpenLine(Board *board, Cell start, Cell end, Direction dir) {
 
 BOOL isAtLeastHalfOpenLine(Board *board, Cell start, Cell end, Direction dir) {
     // ラインとして少なくとも片側が空いているかどうかの判定関数
+    // 盤外のセルは「空いている」とはみなさない。
+    // 各サイドごとに盤内かを確認してから参照する（片側だけ盤外のケースがあるため）
 
-    // 両サイドが盤面外の場合
-    if (!isInBoard(start.r - dir.dx, start.c - dir.dy) && !isInBoard(end.r + dir.dx, end.c + dir.dy))
-        return FALSE;
+    Cell prev = {.r = start.r - dir.dx, .c = start.c - dir.dy};
+    Cell next = {.r = end.r + dir.dx, .c = end.c + dir.dy};
 
-    return (
-        board->cells[start.r - dir.dx][start.c - dir.dy] == EMPTY_CELL ||
-        board->cells[end.r + dir.dx][end.c + dir.dy] == EMPTY_CELL
-        );
+    BOOL isPrevOpen = isInBoard(prev.r, prev.c) &&
+                      board->cells[prev.r][prev.c] == EMPTY_CELL;
+    BOOL isNextOpen = isInBoard(next.r, next.c) &&
+                      board->cells[next.r][next.c] == EMPTY_CELL;
+
+    return (isPrevOpen || isNextOpen) ? TRUE : FALSE;
 }
 
 

--- a/tests/test_board.c
+++ b/tests/test_board.c
@@ -399,6 +399,63 @@ void testIsHalfOpenLine(TestResults* results) {
     test_end("IsHalfOpenLine");
 }
 
+void testIsHalfOpenLineAtBoardEdge(TestResults* results) {
+    test_begin("IsHalfOpenLineAtBoardEdge");
+
+    // 盤の上端に接するライン。上側 (0行目) は盤外、下側 (5,9) は O が塞いでいるので
+    // 「少なくとも片側が空いている」は成立しない。
+    Board board;
+    const char *testBoard[] = {
+            NULL,
+            "........X",
+            "........X",
+            "........X",
+            "........X",
+            "........O",
+            ".........",
+            ".........",
+            ".........",
+            "........."
+        };
+    initBoardWithStr(&board, testBoard);
+
+    // initBoard() は 1..BOARD_ROWS しか初期化しないため 0 行目は不定値になる。
+    // 盤外セルを参照していないことを確実に検証するため、空きマスに見える値を入れておく。
+    for (int c = 0; c <= BOARD_COLUMNS; c++) {
+        board.cells[0][c] = EMPTY_CELL;
+    }
+
+    Cell topStart = {.r = 1, .c = 9};
+    Cell topEnd = {.r = 4, .c = 9};
+    Direction dir = {.dx = 1, .dy = 0};
+
+    test_assert(isAtLeastHalfOpenLine(&board, topStart, topEnd, dir) == FALSE,
+                "Cell outside the board should not count as an open end", results);
+
+    // 盤の下端に接するライン。下側は 10 行目で cells 配列の範囲外にあたる。
+    const char *bottomBoard[] = {
+            NULL,
+            ".........",
+            ".........",
+            ".........",
+            ".........",
+            "........O",
+            "........X",
+            "........X",
+            "........X",
+            "........X"
+        };
+    initBoardWithStr(&board, bottomBoard);
+
+    Cell bottomStart = {.r = 6, .c = 9};
+    Cell bottomEnd = {.r = 9, .c = 9};
+
+    test_assert(isAtLeastHalfOpenLine(&board, bottomStart, bottomEnd, dir) == FALSE,
+                "Cell past the last row should not count as an open end", results);
+
+    test_end("IsHalfOpenLineAtBoardEdge");
+}
+
 void testGetGapIdx(TestResults* results) {
     test_begin("GetGapIdx");
 
@@ -965,6 +1022,7 @@ void runBoardTests() {
     testCountContinuousStonesWithGap(&results);
     testIsOpenLine(&results);
     testIsHalfOpenLine(&results);
+    testIsHalfOpenLineAtBoardEdge(&results);
     testGetGapIdx(&results);
     testIsFour(&results);
     testIsMakingDoubleFour(&results);


### PR DESCRIPTION
Fixes #13

## 問題

`isAtLeastHalfOpenLine()` の盤外チェックが `&&`（**両側とも**盤外のときだけ FALSE）になっていたため、片側だけが盤外のラインで盤外セルを参照していた。

```c
if (!isInBoard(start.r - dir.dx, start.c - dir.dy) && !isInBoard(end.r + dir.dx, end.c + dir.dy))
    return FALSE;    // && なので「片側だけ盤外」を弾けない
```

`Board.cells` は `[BOARD_ROWS+1][BOARD_COLUMNS+1]` = `[10][10]` なので、盤の下端に接するラインでは 10 行目、つまり `sizeof(Board)` = 108 バイトの構造体の外側を読む。

## 修正内容

各サイドごとに `isInBoard()` で確認してから参照するよう変更した。盤外のセルは「空いている」とみなさない。同ファイルの `isOpenLine()` および `src/cpu.c` の `__evaluateLengths()` と同じ扱いに揃えている。

```c
BOOL isPrevOpen = isInBoard(prev.r, prev.c) && board->cells[prev.r][prev.c] == EMPTY_CELL;
BOOL isNextOpen = isInBoard(next.r, next.c) && board->cells[next.r][next.c] == EMPTY_CELL;
return (isPrevOpen || isNextOpen) ? TRUE : FALSE;
```

## テスト

`tests/test_board.c` に `IsHalfOpenLineAtBoardEdge` を追加した。

- **上端ケース**（決定的に失敗する回帰テスト）: 1〜4行目の9列目に X、5行目を O で塞いだ盤面。上側は 0 行目で盤外、下側は塞がれているので `FALSE` が正しい。`initBoard()` は 1..BOARD_ROWS しか初期化しないため、テスト側で 0 行目に `EMPTY_CELL` を書き込み、盤外セルを参照していたら必ず露見するようにしている。
- **下端ケース**: 6〜9行目の9列目に X、5行目を O で塞いだ盤面。修正前は配列の範囲外（10行目）を読んでいた箇所。

修正前:

```
[FAIL] Cell outside the board should not count as an open end
[DONE]  Board Tests: 183 passed, 1 failed
```

修正後:

```
[DONE]  Board Tests: 184 passed, 0 failed
```

### AddressSanitizer

修正前は下端ケースで以下が出ていた:

```
ERROR: AddressSanitizer: heap-buffer-overflow on address 0x60b00000041d
READ of size 1 at 0x60b00000041d thread T0
    #0 isAtLeastHalfOpenLine board.c:183
0x60b00000041d is located 1 bytes after 108-byte region
```

修正後は同じ再現コードで検出なし。さらにテストスイート全体を `-fsanitize=address,undefined` でビルドして実行し、全スイート 0 failed かつサニタイザの指摘なしを確認した。

```
$ gcc -fsanitize=address,undefined -Iinclude tests/*.c src/*.c -o test_asan && ./test_asan
[DONE]  Board Tests: 184 passed, 0 failed
...
```

## 補足

`initBoard()` は 0 行目 / 0 列目、および `Board.lastRow` / `lastCol` を初期化していない。本 PR は盤外参照そのものを塞ぐ修正に留めており、初期化については #15 で扱う。
