### PR TITLE
fix: EOF で入力ループが無限に回る問題を修正 (#14)

### DIFF
--- a/include/constants.h
+++ b/include/constants.h
@@ -71,10 +71,15 @@ typedef struct {
 
 typedef enum
 {
+    MODE_QUIT = 0,
     PLAYER_PLAYER = 1,
     PLAYER_CPU = 2,
     CPU_CPU = 3
 } MODE;
+
+// 入力の終了 (EOF や 'q') を表す Move の番兵。盤上の座標とは決して一致しない
+#define QUIT_MOVE_ROW (-1)
+#define QUIT_MOVE_COL (-1)
 
 typedef struct {
     Board board;

--- a/include/ui.h
+++ b/include/ui.h
@@ -5,6 +5,7 @@
 
 
 Move getPlayerInput();
+BOOL isQuitMove(Move move);
 void displayThanksMessage(void);
 void printBoard(Game *game);
 void announceResult(const Game *game);

--- a/src/game.c
+++ b/src/game.c
@@ -5,7 +5,7 @@
 #include "queue.h"
 #include "game.h"
 
-void playGame(int mode);
+GameState playGame(MODE mode);
 char getWinner(Board *board);
 BOOL __isDrawGame(Board *board);
 
@@ -51,6 +51,11 @@ Move getPlayerMove(Game *game) {
     {
         Move move = getPlayerInput();
         printf("row %d, col %d", move.row, move.col);
+
+        // 入力の終了は検証せずそのまま呼び出し元へ返す
+        if (isQuitMove(move))
+            return move;
+
         if (isValidMove(&game->board, move.row, move.col, game->currentPlayer))
         {
             return move;
@@ -90,13 +95,20 @@ void playTurn(Game* game) {
         move = getPlayerMove(game);
     }
 
+    // プレイヤーが 'q' を入力した、または入力が EOF に達した場合
+    if (isQuitMove(move)) {
+        game->gameState = GAME_QUIT;
+        announceResult(game);
+        return;
+    }
+
     applyMove(game, move);
     updateGameState(game, move);
     printBoard(game);
     announceResult(game);
 }
 
-void playGame(int mode)
+GameState playGame(MODE mode)
 {
 
     Game game = initGame(mode);
@@ -111,17 +123,20 @@ void playGame(int mode)
             switchPlayer(&game);
         }
     }
+    return game.gameState;
 }
 
 void runGameLoop() {
     while (TRUE) {
         MODE mode = selectGameMode();
-
-        playGame(mode);
-
-        if (!askForRematch()) {
-            displayThanksMessage();
+        if (mode == MODE_QUIT)
             break;
-        }
+
+        if (playGame(mode) == GAME_QUIT)
+            break;
+
+        if (!askForRematch())
+            break;
     }
+    displayThanksMessage();
 }

--- a/src/ui.c
+++ b/src/ui.c
@@ -112,21 +112,27 @@ void displayThanksMessage(void) {
     printf("================================\n");
 }
 
+BOOL isQuitMove(Move move) {
+    return (move.row == QUIT_MOVE_ROW && move.col == QUIT_MOVE_COL) ? TRUE : FALSE;
+}
+
 Move getPlayerInput() {
     Move move = {0, 0};
+    Move quitMove = {QUIT_MOVE_ROW, QUIT_MOVE_COL};
     char input[8];
 
     while (TRUE)
     {
         printf("Please input row,col (or 'q' to quit): ");
-        
+
+        // EOF (Ctrl-D やパイプ入力の終了) の場合、これ以上入力は得られない
         if (fgets(input, sizeof(input), stdin) == NULL) {
-            continue;
+            printf("\n");
+            return quitMove;
         }
 
         if (input[0] == 'q' || strcmp(input, "quit\n") == 0) {
-            printf("\tGame Ended.\n");
-            exit(0);
+            return quitMove;
         }
 
         if (sscanf(input, " %d , %d ", &move.row, &move.col) != 2 && sscanf(input, " %d %d ", &move.row, &move.col) != 2) {
@@ -148,12 +154,20 @@ MODE selectGameMode() {
         printf("2. Player vs CPU\n");
         printf("3. CPU vs CPU\n");
         printf("Enter mode (1-3): ");
-        
-        if (scanf("%d", &mode) == 1 && mode >= PLAYER_PLAYER && mode <= CPU_CPU) {
+
+        int scanned = scanf("%d", &mode);
+
+        // EOF の場合、これ以上入力は得られない
+        if (scanned == EOF) {
+            printf("\n");
+            return MODE_QUIT;
+        }
+
+        if (scanned == 1 && mode >= PLAYER_PLAYER && mode <= CPU_CPU) {
             clearInputBuffer();
             return (MODE)mode;
         }
-        
+
         printf("Invalid input. Please try again.\n");
         clearInputBuffer();
     }
@@ -171,19 +185,26 @@ void announceResult(const Game* game) {
         case GAME_DRAW:
             printf("The game ended in a draw!\n");
             break;
+        case GAME_QUIT:
+            printf("\tGame Ended.\n");
+            break;
         default:
             printf("[Error] Unexpected game state!\n");
     }
 }
 
 BOOL askForRematch(void) {
-    char response;
+    char response = '\0';
     printf("\nWould you like to play again? (y/n): ");
-    
+
     while (1) {
-        scanf(" %c", &response);
+        // EOF などで文字が読めない場合は、再戦しないものとして扱う
+        if (scanf(" %c", &response) != 1) {
+            printf("\n");
+            return FALSE;
+        }
         clearInputBuffer();
-        
+
         if (response == 'y' || response == 'Y') {
             return TRUE;
         } else if (response == 'n' || response == 'N') {

--- a/tests/test_ui.c
+++ b/tests/test_ui.c
@@ -140,6 +140,71 @@ void testGetPlayerInputWithoutSpace(TestResults* results) {
     test_end("GetPlayerInputWithoutSpace");
 }
 
+void testGetPlayerInputReturnsQuitOnEof(TestResults* results) {
+    test_begin("GetPlayerInputReturnsQuitOnEof");
+
+    // 入力が尽きた (EOF) 場合、プロンプトを出し続けるのではなく終了を返す
+    FILE* stdin_backup = stdin;
+    stdin = fopen("/dev/null", "r");
+
+    Move move = getPlayerInput();
+
+    test_assert(isQuitMove(move) == TRUE,
+                "EOF should be reported as a quit move", results);
+
+    fclose(stdin);
+    stdin = stdin_backup;
+
+    test_end("GetPlayerInputReturnsQuitOnEof");
+}
+
+void testGetPlayerInputReturnsQuitOnQ(TestResults* results) {
+    test_begin("GetPlayerInputReturnsQuitOnQ");
+
+    char input[] = "q\n";
+    FILE* stdin_backup = stdin;
+    stdin = fmemopen(input, sizeof(input), "r");
+
+    Move move = getPlayerInput();
+
+    test_assert(isQuitMove(move) == TRUE,
+                "'q' should be reported as a quit move", results);
+
+    stdin = stdin_backup;
+
+    test_end("GetPlayerInputReturnsQuitOnQ");
+}
+
+void testAskForRematchReturnsFalseOnEof(TestResults* results) {
+    test_begin("AskForRematchReturnsFalseOnEof");
+
+    FILE* stdin_backup = stdin;
+    stdin = fopen("/dev/null", "r");
+
+    test_assert(askForRematch() == FALSE,
+                "EOF should end the rematch loop", results);
+
+    fclose(stdin);
+    stdin = stdin_backup;
+
+    test_end("AskForRematchReturnsFalseOnEof");
+}
+
+void testSelectGameModeReturnsQuitOnEof(TestResults* results) {
+    test_begin("SelectGameModeReturnsQuitOnEof");
+
+    FILE* stdin_backup = stdin;
+    stdin = fopen("/dev/null", "r");
+
+    test_assert(selectGameMode() == MODE_QUIT,
+                "EOF should end the mode selection loop", results);
+
+    fclose(stdin);
+    stdin = stdin_backup;
+
+    test_end("SelectGameModeReturnsQuitOnEof");
+}
+
 void runUiTests() {
     TestResults results = {0, 0, 0};
     test_suite_begin("UI Tests");
@@ -151,7 +216,11 @@ void runUiTests() {
     testGetPlayerInputWithoutComma(&results);
     testGetPlayerInputWithSpace(&results);
     testGetPlayerInputWithoutSpace(&results);
-    
+    testGetPlayerInputReturnsQuitOnEof(&results);
+    testGetPlayerInputReturnsQuitOnQ(&results);
+    testAskForRematchReturnsFalseOnEof(&results);
+    testSelectGameModeReturnsQuitOnEof(&results);
+
     restore_output();
     
     test_suite_end("UI Tests", &results);


### PR DESCRIPTION
Fixes #14

## 問題

`fgets()` が NULL を返しても `continue` していたため、標準入力が EOF（`Ctrl-D`、パイプ入力の終了）になるとプロンプトを出力し続ける無限ループになっていた。

```c
if (fgets(input, sizeof(input), stdin) == NULL) {
    continue;      // EOF でも continue するので永久に回る
}
```

`scanf()` を使う `selectGameMode()` と `askForRematch()` も同じ問題を抱えていた（`askForRematch()` は戻り値を見ずに未初期化の `response` を比較していた）。

## 設計

単純に `exit(0)` を呼ぶとテストから検証できない（テストプロセスごと終了してしまう）ため、**すでに定義済みで未使用だった `GAME_QUIT` を使い、呼び出し元へ終了を伝播させる**形にした。`MODE` にも `MODE_QUIT` を追加している。

```
getPlayerInput()  --(番兵 Move)-->  getPlayerMove()  -->  playTurn()
                                                            |
                                                     gameState = GAME_QUIT
                                                            |
                                            playGame() --> runGameLoop() で終了
```

| ファイル | 変更 |
|---|---|
| `src/ui.c` | `getPlayerInput()` が EOF と `'q'` で終了を表す番兵 `Move` を返す（`exit(0)` を除去） |
| `src/ui.c` | `isQuitMove()` を追加 |
| `src/ui.c` | `selectGameMode()` が EOF で `MODE_QUIT` を返す |
| `src/ui.c` | `askForRematch()` が文字を読めない場合 `FALSE` を返す |
| `src/ui.c` | `announceResult()` に `GAME_QUIT` の分岐を追加（従来は `[Error] Unexpected game state!` に落ちていた） |
| `src/game.c` | `getPlayerMove()` / `playTurn()` が終了を伝播し `gameState` を `GAME_QUIT` にする |
| `src/game.c` | `playGame()` が `GameState` を返す |
| `src/game.c` | `runGameLoop()` が `MODE_QUIT` / `GAME_QUIT` で終了する |
| `include/constants.h` | `MODE_QUIT`、`QUIT_MOVE_ROW` / `QUIT_MOVE_COL` を追加 |

## テスト

`tests/test_ui.c` に4件追加。`stdin` を `/dev/null` に差し替えることで EOF を再現している（既存テストが `fmemopen` で `stdin` を差し替えている手法に合わせた）。

- `GetPlayerInputReturnsQuitOnEof`
- `GetPlayerInputReturnsQuitOnQ`
- `AskForRematchReturnsFalseOnEof`
- `SelectGameModeReturnsQuitOnEof`

修正前は**テストスイートがハングする**（無限ループそのものが症状のため）。20秒で打ち切った時の出力:

```
  [TEST] GetPlayerInputWithoutSpace
  [TEST] GetPlayerInputReturnsQuitOnEof
        <- ここから進まない
```

修正後:

```
[DONE]  Utils Tests: 12 passed, 0 failed
[DONE]  Queue Tests: 120 passed, 0 failed
[DONE]  Board Tests: 182 passed, 0 failed
[DONE]  UI Tests: 28 passed, 0 failed
[DONE]  Game Tests: 21 passed, 0 failed
[DONE]  CPU Tests: 18 passed, 0 failed
```

### 実際のバイナリでの確認

| 入力 | 結果 |
|---|---|
| `printf '1\n5,5\n'`（対局中に EOF） | `Game Ended.` → `Thanks for playing!` で正常終了 (exit 0) |
| `printf '1\nq\n'` | 同上 |
| `printf ''`（モード選択で EOF） | `Thanks for playing!` で正常終了 (exit 0) |
| `printf '3\nn\n'` | 従来どおり対局後に再戦を尋ねて終了 |

## 挙動の変更点

`'q'` で終了した場合にも `Thanks for playing!` が表示されるようになる。従来は `exit(0)` で即座に終了していたため表示されなかった。終了メッセージの経路を1箇所に統一した結果。

## 補足

出力に見える `row -1, col -1` は `getPlayerMove()` に残っているデバッグ用 `printf` によるもので、#17 で削除する。
