### PR TITLE
fix: printBoard が handHistory[-1] を読む問題を修正 (#15)

### DIFF
--- a/src/game.c
+++ b/src/game.c
@@ -10,7 +10,9 @@ char getWinner(Board *board);
 BOOL __isDrawGame(Board *board);
 
 Game initGame(MODE mode) {
-    Game game;
+    // handHistory を含む全メンバを 0 で初期化する。
+    // 未初期化のまま参照されることを防ぐ
+    Game game = {0};
     initBoard(&(game.board));
     game.currentPlayer = PLAYER_X;
     game.gameState = GAME_PLAYING;

--- a/src/ui.c
+++ b/src/ui.c
@@ -60,9 +60,19 @@ static CellDisplayType getCellDisplayType(Board *board, const Hand *lastHand,
     return NORMAL;
 }
 
+// 最後に打たれた手を返す。まだ一手も打たれていない場合は盤外の手を返す
+static Hand getLastHand(const Game *game) {
+    Hand noHand = {.move = {.row = 0, .col = 0}, .player = EMPTY_CELL};
+
+    if (game->moveCount <= 0)
+        return noHand;
+
+    return game->handHistory[game->moveCount - 1];
+}
+
 void printBoard(Game *game) {
     Board *board = &game->board;
-    Hand lastHand = game->handHistory[game->moveCount - 1];
+    Hand lastHand = getLastHand(game);
 
     char nextPlayer = (game->currentPlayer == PLAYER_X) ? PLAYER_O : PLAYER_X;
 
@@ -182,7 +192,11 @@ void announceResult(const Game* game) {
     
     switch (game->gameState) {
         case GAME_PLAYING:
-            printf("Player %c placed at: %d, %d\n", game->currentPlayer, game->handHistory[game->moveCount - 1].move.row, game->handHistory[game->moveCount - 1].move.col);
+            if (game->moveCount > 0) {
+                Hand lastHand = getLastHand(game);
+                printf("Player %c placed at: %d, %d\n",
+                       game->currentPlayer, lastHand.move.row, lastHand.move.col);
+            }
             break;
         case GAME_WIN:
             printf("Congratulations! Player %c wins!\n", game->winner);

--- a/tests/test_ui.c
+++ b/tests/test_ui.c
@@ -1,11 +1,45 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <stddef.h>
 #include "../include/board.h"
 #include "../include/ui.h"
 #include "../include/game.h"
 #include "test_utils.h"
 #include "test_ui.h"
+
+// 与えられた出力関数を実行し、その標準出力を文字列として buffer に取り込む
+static void captureOutput(void (*fn)(Game*), Game* game, char* buffer, size_t size) {
+    const char* path = "test_capture_output.txt";
+
+    FILE* fp = fopen(path, "w");
+    FILE* stdout_backup = stdout;
+    stdout = fp;
+    fn(game);
+    stdout = stdout_backup;
+    fclose(fp);
+
+    buffer[0] = '\0';
+    fp = fopen(path, "r");
+    if (fp) {
+        size_t read = fread(buffer, 1, size - 1, fp);
+        buffer[read] = '\0';
+        fclose(fp);
+    }
+    remove(path);
+}
+
+// handHistory[-1] が重なるバイト列に、盤上のマスに見える Hand を書き込む。
+// printBoard() が moveCount == 0 でも handHistory[moveCount - 1] を読んでいると、
+// このマスが「最後の手」として着色されてしまう。
+static void writeBytesBeforeHandHistory(Game* game, int row, int col) {
+    Hand fake = {.move = {.row = row, .col = col}, .player = PLAYER_X};
+    memcpy((char*)game + offsetof(Game, handHistory) - sizeof(Hand), &fake, sizeof(Hand));
+}
+
+static void announceResultAdapter(Game* game) {
+    announceResult(game);
+}
 
 void testPrintBoard(TestResults* results) {
     test_begin("PrintBoard");
@@ -266,6 +300,40 @@ void testSelectGameModeReturnsQuitOnEof(TestResults* results) {
     test_end("SelectGameModeReturnsQuitOnEof");
 }
 
+void testPrintBoardWithoutAnyMove(TestResults* results) {
+    test_begin("PrintBoardWithoutAnyMove");
+
+    Game game = initGame(PLAYER_PLAYER);
+    writeBytesBeforeHandHistory(&game, 2, 2);
+    game.moveCount = 0;  // まだ一手も打たれていない
+
+    char output[4096];
+    captureOutput(printBoard, &game, output, sizeof(output));
+
+    // 最後の手を表す緑色のエスケープシーケンスが含まれていないこと
+    test_assert(strstr(output, "\x1b[32m") == NULL,
+                "Empty board should not highlight any cell as the last move", results);
+
+    test_end("PrintBoardWithoutAnyMove");
+}
+
+void testAnnounceResultWithoutAnyMove(TestResults* results) {
+    test_begin("AnnounceResultWithoutAnyMove");
+
+    Game game = initGame(PLAYER_PLAYER);
+    writeBytesBeforeHandHistory(&game, 2, 2);
+    game.moveCount = 0;
+    game.gameState = GAME_PLAYING;
+
+    char output[512];
+    captureOutput(announceResultAdapter, &game, output, sizeof(output));
+
+    test_assert(strstr(output, "placed at") == NULL,
+                "Should not report a move when none has been played", results);
+
+    test_end("AnnounceResultWithoutAnyMove");
+}
+
 void runUiTests() {
     TestResults results = {0, 0, 0};
     test_suite_begin("UI Tests");
@@ -274,6 +342,8 @@ void runUiTests() {
 
     testPrintBoard(&results);
     testPrintBoardProhibitedMoveInLastColumn(&results);
+    testPrintBoardWithoutAnyMove(&results);
+    testAnnounceResultWithoutAnyMove(&results);
     testGetPlayerInputExpectedStr(&results);
     testGetPlayerInputWithoutComma(&results);
     testGetPlayerInputWithSpace(&results);


### PR DESCRIPTION
Fixes #15

## 問題

`printBoard()` が `game->handHistory[game->moveCount - 1]` を無条件に読んでいたため、まだ一手も打たれていない初回描画（`playGame()` の開始時、`moveCount == 0`）で **`handHistory[-1]` を参照**していた。配列範囲外アクセスであり、`initGame()` が `handHistory` を初期化していないこともあって、読み出す内容は未初期化メモリになる。値が偶然 1〜9 に収まると、空の盤面上の無関係なマスが「最後の手」として緑色で着色される。

`announceResult()` の `GAME_PLAYING` 分岐（`src/ui.c`）にも同じ範囲外参照があった。現在の呼び出し経路では `moveCount >= 1` のため到達しないが、同じ欠陥なので併せて修正した。

## 修正内容

| ファイル | 変更 |
|---|---|
| `src/ui.c` | `getLastHand()` を追加。`moveCount == 0` の場合は盤外の手 `(0, 0)` を返す |
| `src/ui.c` | `printBoard()` / `announceResult()` が `getLastHand()` を経由するよう変更 |
| `src/game.c` | `initGame()` が `Game game = {0};` で全メンバを 0 初期化するよう変更 |

## テスト

`tests/test_ui.c` に2件追加した。

- `PrintBoardWithoutAnyMove`
- `AnnounceResultWithoutAnyMove`

### 決定的に失敗させる方法

未初期化メモリの中身に依存すると再現性のないテストになるため、**`handHistory[-1]` が占めるバイト列に「盤上のマス (2,2)」に見える値を明示的に書き込んでから**検証している。

```c
static void writeBytesBeforeHandHistory(Game* game, int row, int col) {
    Hand fake = {.move = {.row = row, .col = col}, .player = PLAYER_X};
    memcpy((char*)game + offsetof(Game, handHistory) - sizeof(Hand), &fake, sizeof(Hand));
}
```

書き込み先は `offsetof(Game, handHistory) - sizeof(Hand)` から `sizeof(Hand)` バイトで、`handHistory[-1]` が読む範囲とちょうど一致する。`Game` オブジェクトの内側なので書き込み自体は安全であり、特定の ABI に依存しない。この状態で `moveCount = 0` にすると、修正前は必ずマス (2,2) が着色される。

修正前:

```
[FAIL] Empty board should not highlight any cell as the last move
[FAIL] Should not report a move when none has been played
[DONE]  UI Tests: 24 passed, 2 failed
```

修正後:

```
[DONE]  UI Tests: 26 passed, 0 failed
```

全スイート 0 failed。

### 実際のバイナリでの確認

```
green escapes on the initial board: 0
green escapes in the whole session: 2
```

初回の盤面には着色がなく、着手後は最後の手だけが着色される。

## 補足

`Board.lastRow` / `Board.lastCol` も `initBoard()` で初期化されていないが、これらはコードベース内のどこからも読まれていない（宣言のみ）。使われていないフィールドの整理は別途対応するのが良いと思う。
