### PR TITLE
fix: 最終列の禁じ手が盤面に表示されない問題を修正 (#16)

### DIFF
--- a/src/ui.c
+++ b/src/ui.c
@@ -47,6 +47,19 @@ static void printCell(char cell, CellDisplayType displayType) {
         }
 }
 
+// セルの表示種別を決定する
+static CellDisplayType getCellDisplayType(Board *board, const Hand *lastHand,
+                                          int row, int col, char nextPlayer) {
+    if (row == lastHand->move.row && col == lastHand->move.col)
+        return LAST_MOVE;
+
+    if (board->cells[row][col] == EMPTY_CELL &&
+        isProhibitedMove(board, row, col, nextPlayer))
+        return PROHIBITED;
+
+    return NORMAL;
+}
+
 void printBoard(Game *game) {
     Board *board = &game->board;
     Hand lastHand = game->handHistory[game->moveCount - 1];
@@ -60,23 +73,15 @@ void printBoard(Game *game) {
 
     for (int i = 1; i <= BOARD_ROWS; i++) {
         printf("%d\t", i);
-        
-        for (int j = 1; j < BOARD_COLUMNS; j++) {
-            CellDisplayType displayType = NORMAL;
 
-            if (i == lastHand.move.row && j == lastHand.move.col) {
-                displayType = LAST_MOVE;
-            } else if (board->cells[i][j] == EMPTY_CELL && 
-                      isProhibitedMove(board, i, j, nextPlayer)) {
-                displayType = PROHIBITED;
+        for (int j = 1; j <= BOARD_COLUMNS; j++) {
+            printCell(board->cells[i][j], getCellDisplayType(board, &lastHand, i, j, nextPlayer));
+
+            // 最後の列の後には区切り文字を入れない
+            if (j < BOARD_COLUMNS) {
+                printf(" | ");
             }
-            printCell(board->cells[i][j], displayType);
-            printf(" | ");
         }
-        
-        // 最後の列は特別処理（区切り文字なし）
-        printCell(board->cells[i][BOARD_COLUMNS], 
-                 i == lastHand.move.row && BOARD_COLUMNS == lastHand.move.col);
         printf("\n");
 
         // セパレータの表示

--- a/tests/test_ui.c
+++ b/tests/test_ui.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include "../include/board.h"
 #include "../include/ui.h"
 #include "../include/game.h"
 #include "test_utils.h"
@@ -71,6 +72,66 @@ void testPrintBoard(TestResults* results) {
     remove("test_print_board_output.txt");
     
     test_end("PrintBoard");
+}
+
+// 出力から "<row>\t" で始まる行を取り出す
+static void readBoardRow(const char* path, int row, char* out, size_t size) {
+    char prefix[8];
+    snprintf(prefix, sizeof(prefix), "%d\t", row);
+
+    out[0] = '\0';
+    FILE* fp = fopen(path, "r");
+    if (!fp)
+        return;
+
+    char buffer[256];
+    while (fgets(buffer, sizeof(buffer), fp) != NULL) {
+        if (strncmp(buffer, prefix, strlen(prefix)) == 0) {
+            snprintf(out, size, "%s", buffer);
+            break;
+        }
+    }
+    fclose(fp);
+}
+
+void testPrintBoardProhibitedMoveInLastColumn(TestResults* results) {
+    test_begin("PrintBoardProhibitedMoveInLastColumn");
+
+    // 9列目の 1,2,3,5,6 行目に X。(4,9) に打つと長連 (6連) になるため禁じ手。
+    Game game = initGame(PLAYER_PLAYER);
+    game.board.cells[1][BOARD_COLUMNS] = PLAYER_X;
+    game.board.cells[2][BOARD_COLUMNS] = PLAYER_X;
+    game.board.cells[3][BOARD_COLUMNS] = PLAYER_X;
+    game.board.cells[5][BOARD_COLUMNS] = PLAYER_X;
+    game.board.cells[6][BOARD_COLUMNS] = PLAYER_X;
+
+    // printBoard() は「次の手番」の禁じ手を表示する
+    game.currentPlayer = PLAYER_O;
+    game.moveCount = 1;
+    game.handHistory[0].move.row = 6;
+    game.handHistory[0].move.col = BOARD_COLUMNS;
+    game.handHistory[0].player = PLAYER_X;
+
+    test_assert(isProhibitedMove(&game.board, 4, BOARD_COLUMNS, PLAYER_X) == TRUE,
+                "Test setup: (4, 9) should be a prohibited move", results);
+
+    const char* path = "test_print_board_last_column.txt";
+    FILE* fp = fopen(path, "w");
+    FILE* stdout_backup = stdout;
+    stdout = fp;
+    printBoard(&game);
+    stdout = stdout_backup;
+    fclose(fp);
+
+    char row4[256];
+    readBoardRow(path, 4, row4, sizeof(row4));
+    remove(path);
+
+    // 4行目の最終列が赤い * で表示されていること
+    test_assert(strstr(row4, "\x1b[31m*\x1b[39m\n") != NULL,
+                "Prohibited move in the last column should be marked", results);
+
+    test_end("PrintBoardProhibitedMoveInLastColumn");
 }
 
 void testGetPlayerInputExpectedStr(TestResults* results) {
@@ -147,6 +208,7 @@ void runUiTests() {
     suppress_output();
 
     testPrintBoard(&results);
+    testPrintBoardProhibitedMoveInLastColumn(&results);
     testGetPlayerInputExpectedStr(&results);
     testGetPlayerInputWithoutComma(&results);
     testGetPlayerInputWithSpace(&results);


### PR DESCRIPTION
Fixes #16

## 問題

盤面表示のループが `j < BOARD_COLUMNS` で終わっており、**最終列（9列目）だけが禁じ手チェックを通らない**ため、9列目の禁じ手が赤い `*` で表示されなかった。README の「禁じ手は打つ事ができないため、赤の印で表示されます」という記述と食い違っていた。

さらに最終列の `printCell()` には `CellDisplayType` ではなく比較式の結果（`0` / `1`）が渡されていた。`1 == LAST_MOVE` / `0 == NORMAL` なので偶然動いていたが、`PROHIBITED` を渡す経路自体が存在しなかった。

```c
for (int j = 1; j < BOARD_COLUMNS; j++) { ... }   // 9列目は含まれない

// 最後の列は特別処理（区切り文字なし）
printCell(board->cells[i][BOARD_COLUMNS],
         i == lastHand.move.row && BOARD_COLUMNS == lastHand.move.col);   // BOOL を渡している
```

## 修正内容

表示種別の判定を `getCellDisplayType()` に切り出し、ループを `j <= BOARD_COLUMNS` に変更した。区切り文字 `" | "` の出力だけを条件分岐にしている。最終列の特別扱いがなくなり、判定ロジックの重複も解消した。

```c
for (int j = 1; j <= BOARD_COLUMNS; j++) {
    printCell(board->cells[i][j], getCellDisplayType(board, &lastHand, i, j, nextPlayer));
    if (j < BOARD_COLUMNS) {
        printf(" | ");
    }
}
```

## テスト

`tests/test_ui.c` に `PrintBoardProhibitedMoveInLastColumn` を追加した。

9列目の 1,2,3,5,6 行目に X を置き、`(4,9)` が長連（6連）で禁じ手になる盤面を作る。テストはまず `isProhibitedMove(&board, 4, 9, PLAYER_X) == TRUE` で**前提が成立していること自体を検証**し、そのうえで4行目の出力が赤い `*` で終わることを確認する。

修正前:

```
[TEST] PrintBoardProhibitedMoveInLastColumn
[FAIL] Prohibited move in the last column should be marked
[DONE]  UI Tests: 25 passed, 1 failed
```

（前提の `isProhibitedMove` は PASS しており、判定ではなく表示だけが漏れていることが確認できる）

修正後:

```
[DONE]  UI Tests: 26 passed, 0 failed
```

既存の `testPrintBoard` は盤面出力を1行ずつ完全一致で検証しているが、こちらも変わらず PASS する。つまり禁じ手が無い場合の描画結果はバイト単位で同一。

### 実際の描画

```
	1   2   3   4   5   6   7   8   9

1	  |   |   |   |   |   |   |   | X
	- + - + - + - + - + - + - + - + -
2	  |   |   |   |   |   |   |   | X
	- + - + - + - + - + - + - + - + -
3	  |   |   |   |   |   |   |   | X
	- + - + - + - + - + - + - + - + -
4	  |   |   |   |   |   |   |   | *      <- 赤で表示される
```

## 補足

`tests/test_ui.c` と `src/ui.c` は #14 / #15 の PR でも変更しているため、マージ順によっては軽微なコンフリクトが出る可能性がある。必要であればリベースします。
