### PR TITLE
fix: getPlayerMove のデバッグ用 printf を削除 (#17)

### DIFF
--- a/include/game.h
+++ b/include/game.h
@@ -8,4 +8,5 @@ Game initGame(MODE mode);
 void switchPlayer(Game *game);
 BOOL isGameOver(Board *board, int row, int col, char player);
 BOOL isValidMove(Board *board, int row, int col, char playerMark);
+Move getPlayerMove(Game *game);
 #endif

--- a/src/game.c
+++ b/src/game.c
@@ -53,8 +53,6 @@ Move getPlayerMove(Game *game) {
     while (TRUE)
     {
         Move move = getPlayerInput();
-        printf("row %d, col %d", move.row, move.col);
-
         // 入力の終了は検証せずそのまま呼び出し元へ返す
         if (isQuitMove(move))
             return move;

--- a/tests/test_game.c
+++ b/tests/test_game.c
@@ -155,6 +155,42 @@ void testValidateInputFailedNotEmpty(TestResults* results) {
 
 
 
+void testGetPlayerMoveDoesNotPrintDebugOutput(TestResults* results) {
+    test_begin("GetPlayerMoveDoesNotPrintDebugOutput");
+
+    Game game = initGame(PLAYER_PLAYER);
+
+    char input[] = "5,5\n";
+    FILE* stdin_backup = stdin;
+    stdin = fmemopen(input, sizeof(input), "r");
+
+    const char* path = "test_get_player_move_output.txt";
+    FILE* fp = fopen(path, "w");
+    FILE* stdout_backup = stdout;
+    stdout = fp;
+    Move move = getPlayerMove(&game);
+    stdout = stdout_backup;
+    fclose(fp);
+
+    stdin = stdin_backup;
+
+    char output[512] = "";
+    fp = fopen(path, "r");
+    if (fp) {
+        size_t read = fread(output, 1, sizeof(output) - 1, fp);
+        output[read] = '\0';
+        fclose(fp);
+    }
+    remove(path);
+
+    test_assert(move.row == 5 && move.col == 5,
+                "Should return the entered move", results);
+    test_assert(strstr(output, "row 5, col 5") == NULL,
+                "Should not print debug output for the entered move", results);
+
+    test_end("GetPlayerMoveDoesNotPrintDebugOutput");
+}
+
 void runGameTests() {
     TestResults results = {0, 0, 0};
     test_suite_begin("Game Tests");
@@ -168,7 +204,8 @@ void runGameTests() {
     testValidateInputExpectedRange(&results);
     testValidateInputFailedOutOfRange(&results);
     testValidateInputFailedNotEmpty(&results);
-    
+    testGetPlayerMoveDoesNotPrintDebugOutput(&results);
+
     restore_output();
 
     test_suite_end("Game Tests", &results);


### PR DESCRIPTION
Fixes #17

## 問題

`getPlayerMove()` にデバッグ用と思われる `printf` が残っていた。改行が無いため、直後の盤面ヘッダやエラーメッセージと同じ行に連結されて表示されていた。

```
Please input row,col (or 'q' to quit): row 5, col 5	1   2   3   4   5   6   7   8   9
Please input row,col (or 'q' to quit): row 5, col 5Error: The 5, 5 is already marked.
```

## 修正内容

`src/game.c` から該当の `printf` を削除した。テストから呼べるように `getPlayerMove()` を `include/game.h` に公開している。

修正後:

```
Please input row,col (or 'q' to quit): 	1   2   3   4   5   6   7   8   9
Please input row,col (or 'q' to quit): Error: The 5, 5 is already marked.
```

## テスト

`tests/test_game.c` に `GetPlayerMoveDoesNotPrintDebugOutput` を追加した。`stdin` を `fmemopen` で差し替えて `5,5` を入力し、`stdout` をファイルに退避して `getPlayerMove()` の出力を検証する。

- 入力した手がそのまま返ること
- 出力に `row 5, col 5` が含まれないこと

修正前:

```
[TEST] GetPlayerMoveDoesNotPrintDebugOutput
[FAIL] Should not print debug output for the entered move
[DONE]  Game Tests: 22 passed, 1 failed
```

修正後:

```
[DONE]  Game Tests: 23 passed, 0 failed
```

全スイート 0 failed。
