### PR TITLE
fix: 黒に合法手が無い局面を白の勝ちとして決着させる (#26)

### DIFF
--- a/include/board.h
+++ b/include/board.h
@@ -5,6 +5,7 @@
 void initBoard(Board *board);
 BOOL boardIsFull(Board *board);
 BOOL isInBoard(int r, int c);
+BOOL hasLegalMove(Board *board, char playerMark);
 BOOL isWinMove(Board *board, int r, int c, char playerMark);
 BOOL isMakingOverLine(Board *board, int r, int c, char playerMark);
 BOOL isOpenLine(Board *board, Cell start, Cell end, Direction dir);

--- a/include/game.h
+++ b/include/game.h
@@ -9,4 +9,5 @@ void switchPlayer(Game *game);
 BOOL isGameOver(Board *board, int row, int col, char player);
 BOOL isValidMove(Board *board, int row, int col, char playerMark);
 Move getPlayerMove(Game *game);
+void playTurn(Game *game);
 #endif

--- a/include/ui.h
+++ b/include/ui.h
@@ -7,6 +7,7 @@
 Move getPlayerInput();
 BOOL isQuitMove(Move move);
 void displayThanksMessage(void);
+void announceNoLegalMove(char player);
 void printBoard(Game *game);
 void announceResult(const Game *game);
 void printGameStatus(int turnCounts, char player);

--- a/src/board.c
+++ b/src/board.c
@@ -39,6 +39,20 @@ BOOL isInBoard(int r, int c) {
     return FALSE;
 }
 
+// 着手可能な点 (空点かつ禁じ手でない点) が1つでも存在するかの判定関数。
+// 白には禁じ手が無いため、白の場合は空点があるかどうかと同義になる。
+BOOL hasLegalMove(Board *board, char playerMark) {
+    for (int r = 1; r <= BOARD_ROWS; r++) {
+        for (int c = 1; c <= BOARD_COLUMNS; c++) {
+            if (board->cells[r][c] != EMPTY_CELL)
+                continue;
+            if (!isProhibitedMove(board, r, c, playerMark))
+                return TRUE;
+        }
+    }
+    return FALSE;
+}
+
 // 特定の方向の連続した石の数を数える共通関数
 static int countContinuousStones(Board *board, int r, int c, int dx, int dy, char playerMark) {
     int length = 1;  // 置いた石から開始

--- a/src/cpu.c
+++ b/src/cpu.c
@@ -68,9 +68,10 @@ int negaMax(Board *board, int depth, char playerMark, int lastRow, int lastCol, 
         }
     }
 
-    // 合法手が1つも無い場合は番兵を返さず、現局面の評価値を返す
+    // 合法手が1つも無い場合 (空点は残っているが全て禁じ手)、
+    // 手番側の負けが確定している (docs/renju-rules.md)
     if (maxScore == NO_LEGAL_MOVE_SCORE)
-        return evaluate(board, playerMark);
+        return -(TERMINAL_WIN_SCORE + depth);
 
     return maxScore;
 }

--- a/src/game.c
+++ b/src/game.c
@@ -83,9 +83,35 @@ void updateGameState(Game *game, Move move){
     }
 }
 
+// 着手する前に決着しているかを判定する。
+// 判定順序は docs/renju-rules.md を参照 (満局を先に見ることで、
+// 禁じ手を持たない白が「打てない」ケースが引き分けになる)
+static BOOL settleBeforeMove(Game *game) {
+    if (boardIsFull(&game->board)) {
+        game->gameState = GAME_DRAW;
+        return TRUE;
+    }
+
+    if (!hasLegalMove(&game->board, game->currentPlayer)) {
+        // 空点が全て禁じ手。禁点に打たされたものとみなし手番側の負けとする
+        announceNoLegalMove(game->currentPlayer);
+        game->gameState = GAME_WIN;
+        game->winner = (game->currentPlayer == PLAYER_X) ? PLAYER_O : PLAYER_X;
+        return TRUE;
+    }
+
+    return FALSE;
+}
+
 // 1ターンの処理
 void playTurn(Game* game) {
     Move move;
+
+    if (settleBeforeMove(game)) {
+        announceResult(game);
+        return;
+    }
+
     printGameStatus(game->moveCount + 1, game->currentPlayer);
 
     if (

--- a/src/ui.c
+++ b/src/ui.c
@@ -122,6 +122,10 @@ void displayGameRules(void) {
 }
 
 
+void announceNoLegalMove(char player) {
+    printf("Player %c has no legal move left. Every empty point is a forbidden move.\n", player);
+}
+
 void displayThanksMessage(void) {
     printf("\n\tThanks for playing!\n\n");
     printf("================================\n");

--- a/tests/test_board.c
+++ b/tests/test_board.c
@@ -1010,6 +1010,61 @@ void testIsMakingDoubleThree(TestResults* results) {
     test_end("IsMakingDoubleThree");
 }
 
+void testHasLegalMove(TestResults* results) {
+    test_begin("HasLegalMove");
+
+    Board board = __prepareBoard();
+    test_assert(hasLegalMove(&board, PLAYER_X) == TRUE,
+                "Empty board should have legal moves for black", results);
+    test_assert(hasLegalMove(&board, PLAYER_O) == TRUE,
+                "Empty board should have legal moves for white", results);
+
+    // 空点が (4,9) だけで、そこは黒にとって長連になる禁じ手。
+    // 白には禁じ手が無いので白は打てる。
+    const char *trapped[] = {
+            NULL,
+            "OOOOOOOOX",
+            "OOOOOOOOX",
+            "OOOOOOOOX",
+            "OOOOOOOO.",
+            "OOOOOOOOX",
+            "OOOOOOOOX",
+            "OOOOOOOOX",
+            "OOOOOOOOX",
+            "OOOOOOOOX"
+        };
+    initBoardWithStr(&board, trapped);
+
+    test_assert(isProhibitedMove(&board, 4, BOARD_COLUMNS, PLAYER_X) == TRUE,
+                "Test setup: the only empty cell should be prohibited for black", results);
+    test_assert(hasLegalMove(&board, PLAYER_X) == FALSE,
+                "Black should have no legal move when every empty cell is prohibited", results);
+    test_assert(hasLegalMove(&board, PLAYER_O) == TRUE,
+                "White has no forbidden moves, so an empty cell is always legal", results);
+
+    // 満局
+    const char *full[] = {
+            NULL,
+            "OOOOOOOOX",
+            "OOOOOOOOX",
+            "OOOOOOOOX",
+            "OOOOOOOOX",
+            "OOOOOOOOX",
+            "OOOOOOOOX",
+            "OOOOOOOOX",
+            "OOOOOOOOX",
+            "OOOOOOOOX"
+        };
+    initBoardWithStr(&board, full);
+
+    test_assert(hasLegalMove(&board, PLAYER_X) == FALSE,
+                "Full board should have no legal move for black", results);
+    test_assert(hasLegalMove(&board, PLAYER_O) == FALSE,
+                "Full board should have no legal move for white", results);
+
+    test_end("HasLegalMove");
+}
+
 void runBoardTests() {
     TestResults results = {0, 0, 0};
     test_suite_begin("Board Tests");
@@ -1029,6 +1084,7 @@ void runBoardTests() {
     testIsMakingGreatFour(&results);
     testIsThree(&results);
     testIsMakingDoubleThree(&results);
+    testHasLegalMove(&results);
     
     restore_output();
     

--- a/tests/test_cpu.c
+++ b/tests/test_cpu.c
@@ -261,6 +261,37 @@ void testIsGameOverRejectsOutOfBoardCell(TestResults* results) {
     test_end("IsGameOverRejectsOutOfBoardCell");
 }
 
+void testNegaMaxScoresNoLegalMoveAsLoss(TestResults* results) {
+    test_begin("NegaMaxScoresNoLegalMoveAsLoss");
+
+    // 空点が (4,9) だけで、そこは黒にとって長連になる禁じ手。
+    // 黒番のこのノードは負けが確定しているので、決定的な負けスコアを返すこと。
+    // (docs/renju-rules.md の確定仕様)
+    Board board;
+    const char *trapped[] = {
+            NULL,
+            "OOOOOOOOX",
+            "OOOOOOOOX",
+            "OOOOOOOOX",
+            "OOOOOOOO.",
+            "OOOOOOOOX",
+            "OOOOOOOOX",
+            "OOOOOOOOX",
+            "OOOOOOOOX",
+            "OOOOOOOOX"
+        };
+    initBoardWithStr(&board, trapped);
+
+    int bestRow = -1, bestCol = -1;
+    int score = negaMax(&board, 1, PLAYER_X, 0, 0, &bestRow, &bestCol,
+                        -SCORE_INFINITY, SCORE_INFINITY);
+
+    test_assert(score == -(TERMINAL_WIN_SCORE + 1),
+                "A node with no legal move should score as a loss", results);
+
+    test_end("NegaMaxScoresNoLegalMoveAsLoss");
+}
+
 void runCPUTests() {
     TestResults results = {0, 0, 0};
     test_suite_begin("CPU Tests");
@@ -280,6 +311,7 @@ void runCPUTests() {
     testGetCpuMoveTakesImmediateWin(&results);
     testGetCpuMoveBlocksImmediateLoss(&results);
     testIsGameOverRejectsOutOfBoardCell(&results);
+    testNegaMaxScoresNoLegalMoveAsLoss(&results);
 
     restore_output();
     

--- a/tests/test_game.c
+++ b/tests/test_game.c
@@ -191,6 +191,79 @@ void testGetPlayerMoveDoesNotPrintDebugOutput(TestResults* results) {
     test_end("GetPlayerMoveDoesNotPrintDebugOutput");
 }
 
+// 空点が (4,9) だけで、そこは黒にとって長連になる禁じ手の局面
+static void setUpBlackTrappedBoard(Game* game) {
+    const char *trapped[] = {
+            NULL,
+            "OOOOOOOOX",
+            "OOOOOOOOX",
+            "OOOOOOOOX",
+            "OOOOOOOO.",
+            "OOOOOOOOX",
+            "OOOOOOOOX",
+            "OOOOOOOOX",
+            "OOOOOOOOX",
+            "OOOOOOOOX"
+        };
+    initBoardWithStr(&game->board, trapped);
+    game->moveCount = 1;
+    game->handHistory[0].move.row = 9;
+    game->handHistory[0].move.col = BOARD_COLUMNS;
+    game->handHistory[0].player = PLAYER_O;
+}
+
+void testBlackLosesWhenNoLegalMoveRemains(TestResults* results) {
+    test_begin("BlackLosesWhenNoLegalMoveRemains");
+
+    // docs/renju-rules.md の確定仕様:
+    // 手番側に合法手が1つも無い場合はその手番側の負け。
+    // 黒は禁点に打たされたものとみなし、白の勝ちになる。
+    Game game = initGame(CPU_CPU);
+    setUpBlackTrappedBoard(&game);
+    game.currentPlayer = PLAYER_X;
+
+    playTurn(&game);
+
+    test_assert(game.gameState == GAME_WIN,
+                "Game should end when black has no legal move", results);
+    test_assert(game.winner == PLAYER_O,
+                "White should win when black is forced onto a forbidden point", results);
+
+    test_end("BlackLosesWhenNoLegalMoveRemains");
+}
+
+void testFullBoardIsDrawNotLoss(TestResults* results) {
+    test_begin("FullBoardIsDrawNotLoss");
+
+    // 満局は「合法手が無い」より先に引き分けと判定されること
+    const char *full[] = {
+            NULL,
+            "OOOOOOOOX",
+            "OOOOOOOOX",
+            "OOOOOOOOX",
+            "OOOOOOOOX",
+            "OOOOOOOOX",
+            "OOOOOOOOX",
+            "OOOOOOOOX",
+            "OOOOOOOOX",
+            "OOOOOOOOX"
+        };
+    Game game = initGame(CPU_CPU);
+    initBoardWithStr(&game.board, full);
+    game.moveCount = 1;
+    game.handHistory[0].move.row = 9;
+    game.handHistory[0].move.col = BOARD_COLUMNS;
+    game.handHistory[0].player = PLAYER_O;
+    game.currentPlayer = PLAYER_X;
+
+    playTurn(&game);
+
+    test_assert(game.gameState == GAME_DRAW,
+                "Full board should be a draw", results);
+
+    test_end("FullBoardIsDrawNotLoss");
+}
+
 void runGameTests() {
     TestResults results = {0, 0, 0};
     test_suite_begin("Game Tests");
@@ -205,6 +278,8 @@ void runGameTests() {
     testValidateInputFailedOutOfRange(&results);
     testValidateInputFailedNotEmpty(&results);
     testGetPlayerMoveDoesNotPrintDebugOutput(&results);
+    testBlackLosesWhenNoLegalMoveRemains(&results);
+    testFullBoardIsDrawNotLoss(&results);
 
     restore_output();
 


### PR DESCRIPTION
Fixes #26

#25 (`docs/renju-rules.md`) で確定した仕様を実装します。

## 確定仕様

> 手番側に合法手（空点かつ禁じ手でない点）が1つも存在しない場合、その手番側の負けとする。

判定順序は **五 → 満局 → 合法手なし**。満局を先に評価することで、禁じ手を持たない白が「打てない」ケース（＝盤面が埋まっている）は自動的に引き分けになります。

## 修正内容

| ファイル | 変更 |
|---|---|
| `src/board.c` | `hasLegalMove()` を追加。空点を走査し、禁じ手でない点が1つでもあれば `TRUE` |
| `src/game.c` | `playTurn()` が着手を要求する**前**に `settleBeforeMove()` で決着を判定する |
| `src/ui.c` | `announceNoLegalMove()` で決着理由を表示する |
| `src/cpu.c` | `negaMax()` が合法手の無いノードを負けとして評価する |

### negaMax の変更について

#19 では、合法手が無いノードは番兵スコアを避けるために `evaluate()`（現局面のヒューリスティック評価）を返していました。仕様が確定した今、このノードは**負けが確定している**ので `-(TERMINAL_WIN_SCORE + depth)` を返すのが正しくなります。これにより CPU は「相手を禁点に追い込む手」を勝ち筋として正しく評価します。

## テスト

7アサート追加。いずれも修正前に失敗することを確認済み。

**`tests/test_board.c` — `HasLegalMove`**

- 空盤では黒・白ともに合法手あり
- 空点が (4,9) だけでそこが黒の長連になる盤面: 黒は合法手なし / **白は合法手あり**（白に禁じ手が無いことの検証）
- 満局では両者とも合法手なし

**`tests/test_game.c`**

- `BlackLosesWhenNoLegalMoveRemains` — その局面で `playTurn()` を実行すると `gameState == GAME_WIN` かつ `winner == PLAYER_O`
- `FullBoardIsDrawNotLoss` — 満局では「合法手なし」より先に `GAME_DRAW` になる（判定順序の回帰テスト）

**`tests/test_cpu.c`**

- `NegaMaxScoresNoLegalMoveAsLoss` — 合法手の無いノードが `-(TERMINAL_WIN_SCORE + depth)` を返す

修正前:

```
[FAIL] Game should end when black has no legal move
[FAIL] White should win when black is forced onto a forbidden point
[DONE]  Game Tests: 22 passed, 2 failed
...
[FAIL] A node with no legal move should score as a loss
[DONE]  CPU Tests: 23 passed, 1 failed
```

修正後（全スイート）:

```
[DONE]  Utils Tests: 12 passed, 0 failed
[DONE]  Queue Tests: 120 passed, 0 failed
[DONE]  Board Tests: 191 passed, 0 failed
[DONE]  UI Tests: 30 passed, 0 failed
[DONE]  Game Tests: 24 passed, 0 failed
[DONE]  CPU Tests: 24 passed, 0 failed
```

`-fsanitize=address,undefined` でビルドしたテストスイートも指摘なしで全 PASS。CPU vs CPU で実際に対局が最後まで進むことも確認しました。

## 補足

- テスト用の盤面（片側 8 列を全て O で埋めたもの）は実戦で到達しうる配置ではありませんが、「空点が全て黒の禁じ手」という条件を明確に作るための最小構成です。
- `playTurn()` をテストから呼べるように `game.h` に、`hasLegalMove()` を `board.h` に公開しました。
- #22 / #24 とマージ順が前後する場合、`src/game.c` と `src/ui.c` で軽微なコンフリクトが出る可能性があります。
