### PR TITLE
fix: テスト失敗時に make test が非 0 を返すようにする (#27)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ clean:
 TEST_TARGET := tests/build/test
 TEST_BUILD_DIR := tests/build
 
-TEST_SRCS := tests/test_main.c tests/test_utils.c tests/test_board.c tests/test_ui.c tests/test_game.c tests/test_queue.c tests/test_cpu.c
+TEST_SRCS := tests/test_main.c tests/test_runner.c tests/test_utils.c tests/test_board.c tests/test_ui.c tests/test_game.c tests/test_queue.c tests/test_cpu.c
 TEST_OBJS := $(TEST_SRCS:tests/%.c=$(TEST_BUILD_DIR)/%.o) $(COMMON_SRCS:src/%.c=$(TEST_BUILD_DIR)/%.o)
 
 $(TEST_TARGET): $(TEST_OBJS)

--- a/tests/test_board.c
+++ b/tests/test_board.c
@@ -1065,7 +1065,7 @@ void testHasLegalMove(TestResults* results) {
     test_end("HasLegalMove");
 }
 
-void runBoardTests() {
+int runBoardTests(void) {
     TestResults results = {0, 0, 0};
     test_suite_begin("Board Tests");
     
@@ -1089,4 +1089,5 @@ void runBoardTests() {
     restore_output();
     
     test_suite_end("Board Tests", &results);
+    return results.failed;
 }

--- a/tests/test_board.h
+++ b/tests/test_board.h
@@ -1,6 +1,6 @@
 #ifndef TEST_BOARD_H
 #define TEST_BOARD_H
 
-void runBoardTests();
+int runBoardTests(void);
 
 #endif

--- a/tests/test_cpu.c
+++ b/tests/test_cpu.c
@@ -292,7 +292,7 @@ void testNegaMaxScoresNoLegalMoveAsLoss(TestResults* results) {
     test_end("NegaMaxScoresNoLegalMoveAsLoss");
 }
 
-void runCPUTests() {
+int runCPUTests(void) {
     TestResults results = {0, 0, 0};
     test_suite_begin("CPU Tests");
     
@@ -316,4 +316,5 @@ void runCPUTests() {
     restore_output();
     
     test_suite_end("CPU Tests", &results);
+    return results.failed;
 }

--- a/tests/test_cpu.h
+++ b/tests/test_cpu.h
@@ -1,6 +1,6 @@
 #ifndef TEST_CPU_H
 #define TEST_CPU_H
 
-void runCPUTests();
+int runCPUTests(void);
 
 #endif

--- a/tests/test_game.c
+++ b/tests/test_game.c
@@ -264,7 +264,7 @@ void testFullBoardIsDrawNotLoss(TestResults* results) {
     test_end("FullBoardIsDrawNotLoss");
 }
 
-void runGameTests() {
+int runGameTests(void) {
     TestResults results = {0, 0, 0};
     test_suite_begin("Game Tests");
     
@@ -284,5 +284,6 @@ void runGameTests() {
     restore_output();
 
     test_suite_end("Game Tests", &results);
+    return results.failed;
 }
 

--- a/tests/test_game.h
+++ b/tests/test_game.h
@@ -1,6 +1,6 @@
 #ifndef TEST_GAME_H
 #define TEST_GAME_H
 
-void runGameTests();
+int runGameTests(void);
 
 #endif

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include "test_utils.h"
+#include "test_runner.h"
 #include "test_queue.h"
 #include "test_board.h"
 #include "test_ui.h"
@@ -7,14 +8,17 @@
 #include "test_cpu.h"
 
 int main() {
-    fprintf(stderr, "Starting All Tests...\n\n");
-    runUtilsTests();
-    runQueueTests();
-    runBoardTests();
-    runUiTests();
-    runGameTests();
-    runCPUTests();
+    int failed = 0;
 
-   fprintf(stderr, "\nAll Tests Completed.\n");
-    return 0;
+    fprintf(stderr, "Starting All Tests...\n\n");
+    failed += runRunnerTests();
+    failed += runUtilsTests();
+    failed += runQueueTests();
+    failed += runBoardTests();
+    failed += runUiTests();
+    failed += runGameTests();
+    failed += runCPUTests();
+
+    fprintf(stderr, "\nAll Tests Completed. (%d failed)\n", failed);
+    return exitCodeFor(failed);
 }

--- a/tests/test_queue.c
+++ b/tests/test_queue.c
@@ -108,7 +108,7 @@ void testQueueExtend(TestResults* results) {
     test_end("QueueExtend");
 }
 
-void runQueueTests() {
+int runQueueTests(void) {
     TestResults results = {0, 0, 0};
     test_suite_begin("Queue Tests");
     
@@ -121,4 +121,5 @@ void runQueueTests() {
     restore_output();
     
     test_suite_end("Queue Tests", &results);
+    return results.failed;
 }

--- a/tests/test_queue.h
+++ b/tests/test_queue.h
@@ -1,6 +1,6 @@
 #ifndef TEST_QUEUE_H
 #define TEST_QUEUE_H
 
-void runQueueTests();
+int runQueueTests(void);
 
 #endif

--- a/tests/test_runner.c
+++ b/tests/test_runner.c
@@ -1,0 +1,56 @@
+#include <stdio.h>
+#include "test_utils.h"
+#include "test_runner.h"
+
+/*
+ * テストランナー自身の検証。
+ * 失敗を1件でも記録したら make test が非 0 で終わること (= CI で気づけること) を保証する。
+ */
+
+void testSuiteExitCodeIsZeroWhenAllPass(TestResults* results) {
+    test_begin("SuiteExitCodeIsZeroWhenAllPass");
+
+    TestResults sample = {0, 0, 0};
+    test_assert(TRUE, "passing assertion", &sample);
+    test_assert(TRUE, "passing assertion", &sample);
+
+    test_assert(sample.failed == 0,
+                "All passing assertions should record no failure", results);
+    test_assert(exitCodeFor(sample.failed) == 0,
+                "Exit code should be 0 when nothing failed", results);
+
+    test_end("SuiteExitCodeIsZeroWhenAllPass");
+}
+
+void testSuiteExitCodeIsNonZeroWhenAnyFails(TestResults* results) {
+    test_begin("SuiteExitCodeIsNonZeroWhenAnyFails");
+
+    // 失敗を意図的に記録する。ランナーの検証が目的なので、
+    // このスイート自身の集計には含めない
+    TestResults sample = {0, 0, 0};
+    suppress_stderr();
+    test_assert(FALSE, "intentional failure for runner verification", &sample);
+    restore_stderr();
+
+    test_assert(sample.failed == 1,
+                "A failing assertion should be recorded", results);
+    test_assert(exitCodeFor(sample.failed) != 0,
+                "Exit code should be non-zero when something failed", results);
+
+    test_end("SuiteExitCodeIsNonZeroWhenAnyFails");
+}
+
+int runRunnerTests(void) {
+    TestResults results = {0, 0, 0};
+    test_suite_begin("Runner Tests");
+
+    suppress_output();
+
+    testSuiteExitCodeIsZeroWhenAllPass(&results);
+    testSuiteExitCodeIsNonZeroWhenAnyFails(&results);
+
+    restore_output();
+
+    test_suite_end("Runner Tests", &results);
+    return results.failed;
+}

--- a/tests/test_runner.h
+++ b/tests/test_runner.h
@@ -1,0 +1,6 @@
+#ifndef TEST_RUNNER_H
+#define TEST_RUNNER_H
+
+int runRunnerTests(void);
+
+#endif

--- a/tests/test_ui.c
+++ b/tests/test_ui.c
@@ -334,7 +334,7 @@ void testAnnounceResultWithoutAnyMove(TestResults* results) {
     test_end("AnnounceResultWithoutAnyMove");
 }
 
-void runUiTests() {
+int runUiTests(void) {
     TestResults results = {0, 0, 0};
     test_suite_begin("UI Tests");
     
@@ -356,5 +356,6 @@ void runUiTests() {
     restore_output();
     
     test_suite_end("UI Tests", &results);
+    return results.failed;
 }
 

--- a/tests/test_ui.h
+++ b/tests/test_ui.h
@@ -1,6 +1,6 @@
 #ifndef TEST_UI_H
 #define TEST_UI_H
 
-void runUiTests();
+int runUiTests(void);
 
 #endif

--- a/tests/test_utils.c
+++ b/tests/test_utils.c
@@ -56,6 +56,35 @@ void restore_output(void) {
     }
 }
 
+static FILE* original_stderr = NULL;
+static FILE* stderr_dev_null = NULL;
+
+// 意図的な失敗を記録するテストで、[FAIL] 表示が混ざらないようにする
+void suppress_stderr(void) {
+    if (!original_stderr) {
+        original_stderr = stderr;
+#ifdef _WIN32
+        stderr_dev_null = fopen("NUL", "w");
+#else
+        stderr_dev_null = fopen("/dev/null", "w");
+#endif
+        stderr = stderr_dev_null;
+    }
+}
+
+void restore_stderr(void) {
+    if (original_stderr) {
+        stderr = original_stderr;
+        fclose(stderr_dev_null);
+        original_stderr = NULL;
+        stderr_dev_null = NULL;
+    }
+}
+
+int exitCodeFor(int failedCount) {
+    return failedCount > 0 ? 1 : 0;
+}
+
 
 void testInitBoardWithStr(TestResults* results) {
     test_begin("InitBoardWithStr");
@@ -103,7 +132,7 @@ void testMax(TestResults* results) {
     test_end("Max");
 }
 
-void runUtilsTests() {
+int runUtilsTests(void) {
     TestResults results = {0, 0, 0};
     test_suite_begin("Utils Tests");
     
@@ -115,4 +144,5 @@ void runUtilsTests() {
     restore_output();
     
     test_suite_end("Utils Tests", &results);
+    return results.failed;
 }

--- a/tests/test_utils.h
+++ b/tests/test_utils.h
@@ -18,8 +18,13 @@ void test_assert(BOOL condition, const char* message, TestResults* results);
 
 void suppress_output(void);
 void restore_output(void);
+void suppress_stderr(void);
+void restore_stderr(void);
+
+// 失敗件数からプロセスの終了コードを決める
+int exitCodeFor(int failedCount);
 
 Board __prepareBoard();
 void initBoardWithStr(Board *board, const char *lines[BOARD_ROWS + 1]);
-void runUtilsTests();
+int runUtilsTests(void);
 #endif


### PR DESCRIPTION
Fixes #27

## 問題

各 `runXxxTests()` が失敗件数を返さず、`test_main.c` が常に `return 0` していたため、**テストが失敗しても `make test` が成功扱い**になっていた。CI を入れるとテストが赤でもパイプラインが緑になる。

## 修正内容

| ファイル | 変更 |
|---|---|
| `tests/test_*.h` / `tests/test_*.c` | `runXxxTests()` のシグネチャを `void` → `int` に変更し、`results.failed` を返す |
| `tests/test_main.c` | 全スイートの失敗件数を合計し、`exitCodeFor()` で終了コードを決める |
| `tests/test_utils.c` | `exitCodeFor()` と `suppress_stderr()` / `restore_stderr()` を追加 |
| `tests/test_runner.c` (新規) | 終了コードの規約自体を検証する |
| `Makefile` | `TEST_SRCS` に `tests/test_runner.c` を追加 |

## テスト

終了コードの規約は「テストランナー自身の仕様」なので、`tests/test_runner.c` として独立したスイートを追加した。

- `SuiteExitCodeIsZeroWhenAllPass` — 成功のみを記録した `TestResults` から `exitCodeFor()` が 0 を返す
- `SuiteExitCodeIsNonZeroWhenAnyFails` — 失敗を1件記録した `TestResults` から非 0 を返す

意図的に失敗を記録するため、その間だけ `[FAIL]` の表示を抑制する `suppress_stderr()` を用意している（本物の失敗と紛らわしくならないように）。

### 実際の終了コード

修正前は失敗があっても 0 だった。修正後:

```console
$ make test > /dev/null 2>&1; echo $?
0                     # 全 PASS

# tests/test_queue.c に意図的な失敗を1件仕込む
$ make test > /dev/null 2>&1; echo $?
2                     # 非 0 (テストバイナリ自体は 1、make が 2 を返す)
```

失敗を仕込んだときの出力:

```
[DONE]  Queue Tests: 120 passed, 1 failed
All Tests Completed. (1 failed)
```

合計件数を末尾に出すようにしたので、目視でも気づきやすくなった。

全スイートの結果:

```
[DONE]  Runner Tests: 4 passed, 0 failed
[DONE]  Utils Tests: 12 passed, 0 failed
[DONE]  Queue Tests: 120 passed, 0 failed
[DONE]  Board Tests: 184 passed, 0 failed
[DONE]  UI Tests: 30 passed, 0 failed
[DONE]  Game Tests: 21 passed, 0 failed
[DONE]  CPU Tests: 23 passed, 0 failed
```

## スコープ外にした点

issue の備考に挙げた **`test_end()` が失敗していても無条件に `[PASS]` を表示する問題**は、本 PR に含めていません。直すには `test_end()` のシグネチャ変更が必要で、約50箇所の呼び出し側を書き換えることになり、オープン中の #22 / #24 / #28 と広範にコンフリクトするためです。終了コードで失敗が確実に検出できるようになったので、別 PR で対応するのが安全だと思います。

## 注意

`make test` は `clean` を経由して追跡対象の `./Game` バイナリを削除します（`clean: rm -rf $(BUILD_DIR) $(TARGET)`）。本 PR では `Game` を元に戻してあり差分に含めていませんが、バイナリを追跡対象から外すか、`clean` の対象を見直すことを検討しても良いかもしれません。
